### PR TITLE
Removing CoreTweet for TwitterSharp

### DIFF
--- a/twitter-baby-birding.csproj
+++ b/twitter-baby-birding.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreTweet" Version="1.0.0.483" />
     <PackageReference Include="log4net" Version="2.0.14" />
     <PackageReference Include="MarkovSharp" Version="4.0.32" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
@@ -16,7 +15,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />
     <PackageReference Include="Sanford.Multimedia.Midi" Version="6.6.2" />
-    <PackageReference Include="CoreTweet" Version="1.0.0.483" />
     <PackageReference Include="TwitterSharp" Version="1.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Simple removing Coretweet since we are not using it anymore. 

We are using TweetSharp to fetch tweets.